### PR TITLE
Asynchronous message sending

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,5 @@ gem 'pry-rails'
 
 gem 'carrierwave'
 gem 'mini_magick'
+
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,10 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -294,6 +298,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+//= require jquery
+//= require rails-ujs
+//= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,66 @@
+$(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      let html =
+        `<div class="Message-box">
+          <div class="Message-box__info">
+            <div class="Message-box__info__name">
+              ${message.user_name}
+            </div>
+            <div class="Message-box__info__time">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="Message-box__message">
+            <p class="Message__content">
+              ${message.content}
+            </p>
+            <img class="Message__image" src="${message.image}">
+          </div>
+        </div>`
+      return html;
+    } else {
+      let html =
+      `<div class="Message-box">
+        <div class="Message-box__info">
+          <div class="Message-box__info__name">
+            ${message.user_name}
+          </div>
+          <div class="Message-box__info__time">
+            ${message.created_at}
+          </div>
+        </div>
+        <div class="Message-box__message">
+          <p class="Message__content">
+            ${message.content}
+          </p>
+        </div>
+      </div>`
+      return html;
+    };
+  }
+
+  $('.Form-box').on('submit', function(e){
+    e.preventDefault();
+    let formData = new FormData(this);
+    let url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      let html = buildHTML(data);
+      $('.Messages').append(html);
+      $('.Messages').animate({ scrollTop: $('.Messages')[0].scrollHeight});
+      $('form')[0].reset();
+      $('.Form-box__btn').prop('disabled', false)
+    })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+    });
+  });
+});

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -106,6 +106,7 @@
     background-color: #fafafa;
     height: calc(100vh - 100px - 90px);
     padding:35px 0 0 40px;
+    overflow: scroll;
     .Message-box {
       &__info {
         display: flex;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,6 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# What
ChatSpaceに非同期通信を実装した。以下手順
1:新しいブランチを作成する
2:JavaScriptとjQueryを使用するための準備を
3:これから記述するjsファイルを作成して、jQueryが読み込めることを確認
4:フォームが送信されたら、イベントが発火するようにする
5:イベントが発火したときにAjaxを使用して、messages#createが動くようにする
6:messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
7:jbuilderを使用して、作成したメッセージをJSON形式で返す
8:返ってきたJSONをdoneメソッドで受取り、HTMLを作成
9:作成したHTMLをメッセージ画面の一番下に追加
10:メッセージを送信したとき、メッセージ画面を最下部にスクロールする（※cssにoverflow: scroll;を追加）
11:連続で送信ボタンを押せるようにする
12:非同期に失敗した場合の処理の準備
13:タイムゾーンを日本時間に設定

# Why
メッセージを送信するたびに送信画面にリダイレクトしてビューが毎回再描画されてしまうため、リロードされずにメッセージを送信できるようにする。
![097dfc59b220b6d864677198e722da63 (1)](https://user-images.githubusercontent.com/68668379/90926138-7cff7880-e42d-11ea-9c80-6a2492d36ac5.gif)

